### PR TITLE
Fix SSL messages

### DIFF
--- a/content/_shared/header-govau.md
+++ b/content/_shared/header-govau.md
@@ -6,7 +6,7 @@ menu:
   - link: https://guides.service.gov.au
     text: Guides
 left_title: The .gov.au means it's official
-left_content: Australian Government websites always use a .gov.au domain. Before sharing sensitive information online, make sure you’re on a .gov.au site by inspecting your browser’s address (or 'location') bar.
-right_title: This site is protected by SSL
-right_content: This site is protected by an SSL (Secure Sockets Layer) certificate that’s been signed by the Australian Government. The https:// means all transmitted data is encrypted.
+left_content: Australian Government websites always use a .gov.au domain. Before sharing sensitive information online, make sure you're on a .gov.au site by inspecting your browser's address (or 'location') bar.
+right_title: The site is secure.
+right_content: The https:// ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
 ---

--- a/content/_shared/header-govau.md
+++ b/content/_shared/header-govau.md
@@ -5,8 +5,8 @@ menu:
     text: DTA
   - link: https://guides.service.gov.au
     text: Guides
-left_title: The .gov.au means it's official
-left_content: Australian Government websites always use a .gov.au domain. Before sharing sensitive information online, make sure you're on a .gov.au site by inspecting your browser's address (or 'location') bar.
+left_title: The .gov.au means it’s official
+left_content: Australian Government websites always use a .gov.au domain. Before sharing sensitive information online, make sure you’re on a .gov.au site by inspecting your browser’s address (or 'location') bar.
 right_title: The site is secure.
 right_content: The https:// ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
 ---

--- a/content/_shared/header-govau.md
+++ b/content/_shared/header-govau.md
@@ -7,6 +7,6 @@ menu:
     text: Guides
 left_title: The .gov.au means it’s official
 left_content: Australian Government websites always use a .gov.au domain. Before sharing sensitive information online, make sure you’re on a .gov.au site by inspecting your browser’s address (or 'location') bar.
-right_title: The site is secure.
+right_title: This site is secure.
 right_content: The https:// ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
 ---


### PR DESCRIPTION
The term SSL is confusingly deprecated. Technically SSL is now bad, and TLS good.

It's easier to just say encrypted.

Also, the certificate in most instances is not actually signed by the Australian Government.

Rather it's signed by a CA trusted by your browser.

Have changed to the same text as used by some of the cloud.gov.au pages.

(and also changed some smart-quotes to plain old apostrophes)