### PR TITLE
Fixes typo in select component description

### DIFF
--- a/content/components/_all.yml
+++ b/content/components/_all.yml
@@ -1182,7 +1182,7 @@ responsive-media:
 select:
   name: Select
   description: >
-    Select provides a means to select a single tem from a collapsible list. Use
+    Select provides a means to select a single item from a collapsible list. Use
     of select helps to reduce input errors and screen space. It's commonly used
     to help users enter a value into a form field.
   metatags:


### PR DESCRIPTION
**Summary**
Fixes a small typo in the [Select component description](https://gold.service.gov.au/components/select/) that referred to a  single "tem" instead of a single "item".

**Before & after:**
<img width="400" alt="screen shot 2018-03-02 at 12 06 37 am" src="https://user-images.githubusercontent.com/11636908/36884274-d3dfa222-1dad-11e8-97f6-30bae907cb5c.png">
<img width="400" alt="screen shot 2018-03-02 at 12 07 06 am" src="https://user-images.githubusercontent.com/11636908/36884275-d3ef5f6e-1dad-11e8-96d8-38b157bcdd82.png">
___
 Hello from a fan of this system! ✌️ 🇦🇺 🇺🇸 Great work!